### PR TITLE
[FIX] Correct null point exception when using new configuration without yaml:profile

### DIFF
--- a/inotify-proxy.go
+++ b/inotify-proxy.go
@@ -2,12 +2,13 @@ package main
 
 import (
 	"flag"
+	"os"
+	"strings"
+
 	"github.com/cmuench/inotify-proxy/internal/config"
 	"github.com/cmuench/inotify-proxy/internal/util"
 	"github.com/cmuench/inotify-proxy/internal/watcher"
 	"github.com/gookit/color"
-	"os"
-	"strings"
 )
 
 var Version = "dev"
@@ -74,7 +75,7 @@ func main() {
 
 	for _, e := range c.Entries {
 		color.Style{color.FgCyan, color.OpBold}.Printf("Directory: %s\n", e.Directory)
-		if *e.Profile != "" {
+		if e.Profile != nil {
 			color.Style{color.FgCyan, color.OpBold}.Printf("Profile: %s\n", *e.Profile)
 		}
 		if len(e.Extensions) > 0 {


### PR DESCRIPTION
A configuration like this crashes the inotify-proxy with a null pointer exception when checking for e.Profile
```
---
watch:
  - directory: ./watch-test/
    extensions: [.css, .html]
```

![image](https://user-images.githubusercontent.com/6792844/103640234-ea7cf300-4f4f-11eb-95a0-d551b589eb89.png)
