### PR TITLE
Update Go version to 1.24 and update GitHub Actions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -13,14 +13,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - name: Set up Go 1.x
-      uses: actions/setup-go@v2
+    - name: Set up Go
+      uses: actions/setup-go@v5
       with:
-        go-version: ^1.14
+        go-version: 1.24
       id: go
 
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Get dependencies
       run: |

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -10,20 +10,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v5
         with:
-          go-version: 1.14
+          go-version: 1.24
 
       - name: Set GITHUB_REF_SLUG
         id: set_github_ref_slug
         run: echo GITHUB_REF_SLUG=${GITHUB_REF#refs/tags/} >> $GITHUB_ENV
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v2
+        uses: goreleaser/goreleaser-action@v6
         with:
           version: latest
           args: release --rm-dist

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/cmuench/inotify-proxy
 
-go 1.23.0
-
-toolchain go1.24.3
+go 1.24.0
 
 require (
 	github.com/gookit/color v1.6.0


### PR DESCRIPTION
This PR updates the Go version to 1.24 across the project. It updates `go.mod` and the GitHub Actions workflows. Additionally, it updates the versions of `actions/setup-go`, `actions/checkout`, and `goreleaser/goreleaser-action` to their latest major versions to ensure compatibility and stability. No Dockerfile was found in the repository, so no docker setup update was performed.

---
*PR created automatically by Jules for task [1108318232184227884](https://jules.google.com/task/1108318232184227884) started by @cmuench*