### PR TITLE
Update Maintenance Badge to 2026

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # inotify-proxy
 
-![Maintenance Badge](https://img.shields.io/maintenance/yes/2025.svg)
+![Maintenance Badge](https://img.shields.io/maintenance/yes/2026.svg)
 [![Go Report Card](https://goreportcard.com/badge/github.com/cmuench/inotify-proxy)](https://goreportcard.com/report/github.com/cmuench/inotify-proxy)
 [![Go Github Action Workflow](https://github.com/cmuench/inotify-proxy/workflows/Go/badge.svg)](https://github.com/cmuench/inotify-proxy/actions?query=workflow%3AGo)
 


### PR DESCRIPTION
Updated the Maintenance Badge year in `README.md` to 2026. This reflects the continued maintenance status of the project for the current year.

---
*PR created automatically by Jules for task [9861959244849114376](https://jules.google.com/task/9861959244849114376) started by @cmuench*