### PR TITLE
🔒 [security fix] handle file touch and walk errors gracefully to prevent DoS

### DIFF
--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -64,7 +64,7 @@ func walkSingleDirectory(we config.WatchEntry) {
 	})
 
 	if err != nil {
-		panic(err)
+		color.Errorf("Error walking directory %s: %s\n", we.Directory, err.Error())
 	}
 }
 
@@ -98,7 +98,7 @@ func isFileChanged(path string) bool {
 			err := os.Chtimes(path, currentTime, currentModificationTime)
 
 			if err != nil {
-				panic("Error touching file" + path)
+				color.Errorf("Error touching file %s: %s\n", path, err.Error())
 			}
 
 			fileMap[path] = NodeInfo{


### PR DESCRIPTION
This PR fixes a Denial of Service (DoS) vulnerability where the application would panic and crash if it encountered an error during file system operations (e.g., permission denied when touching a file or walking a directory).

🎯 **What:** The vulnerability fixed is an unhandled error leading to a panic in `internal/watcher/watcher.go`.
⚠️ **Risk:** A malicious or accidental environmental condition (like a read-only file or an inaccessible directory) could cause the `inotify-proxy` process to terminate unexpectedly, disrupting the file-watching service.
🛡️ **Solution:** Replaced `panic` calls with graceful error logging using `color.Errorf`. The logic also ensures that the file state is updated even if a touch operation fails, preventing the tool from entering a loop of repeated failures and log flooding.

---
*PR created automatically by Jules for task [8113272787844227418](https://jules.google.com/task/8113272787844227418) started by @cmuench*