### PR TITLE
🧹 Replace panic with error logging in watcher

### DIFF
--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -64,7 +64,7 @@ func walkSingleDirectory(we config.WatchEntry) {
 	})
 
 	if err != nil {
-		panic(err)
+		color.Errorf("Error during directory walk: %v\n", err)
 	}
 }
 
@@ -98,7 +98,8 @@ func isFileChanged(path string) bool {
 			err := os.Chtimes(path, currentTime, currentModificationTime)
 
 			if err != nil {
-				panic("Error touching file" + path)
+				color.Errorf("Error touching file %s: %v\n", path, err)
+				return false
 			}
 
 			fileMap[path] = NodeInfo{


### PR DESCRIPTION
🎯 **What:** The code health issue addressed is the usage of `panic` for error handling in the `watcher` package.
💡 **Why:** This improves maintainability and robustness by preventing the application from crashing due to transient I/O or filesystem errors.
✅ **Verification:** Verified by running `make test`, `make format`, and `go vet`. Also manually inspected the code.
✨ **Result:** The application now logs errors instead of panicking, and gracefully handles failures in `walkSingleDirectory` and `isFileChanged`.

Note: I've checked for merge conflicts as requested in PR comments and found none in the current codebase.

---
*PR created automatically by Jules for task [15536891166069129012](https://jules.google.com/task/15536891166069129012) started by @cmuench*